### PR TITLE
Fixed line breaks and non-breaking spaces in text previews

### DIFF
--- a/web/src/components/MixedGrid.js
+++ b/web/src/components/MixedGrid.js
@@ -15,10 +15,12 @@ const gridSx = {
   ".topArticles": {
     display: "grid",
     gridTemplateColumns: "1fr 1fr 1fr",
-    gridTemplateRows: "1fr repeat(2, 0.5fr)",
+    gridTemplateRows: "auto auto auto",
+    // old: repeat(2, 0.5fr)
     gridColumnGap: "0px",
     gridRowGap: "0px",
     paddingInline: "2vw",
+    alignItems: "stretch",
   },
 
   ".div4, .div5, .div6, .div7, .div8, .blogArticle, .archiveArticle": {
@@ -38,6 +40,19 @@ const gridSx = {
     display: "flex",
     borderBottom: "1px solid rgba(0, 0, 0, .2)",
     alignItems: "center",
+  },
+  
+  ".div4.fullWidthContent": {
+    flexDirection: 'column',
+    justifyContent: 'start',
+  },
+  
+  ".div4content.fullWidth": {
+    minWidth: "100%",
+  },
+
+  ".div4.adjustHeight": {
+    height: 'auto',
   },
 
   ".div4image": {
@@ -90,8 +105,24 @@ export default function MixedGrid(props) {
 
   var isMobile = useIsMobile();
 
+  const renderAd = () => {
+    if (props.home && props.adContent) {
+      return (
+        <div className="adSpace">
+          <a href="https://qrco.de/be9Mh6"
+            target="_blank"
+            rel="noreferrer">
+            <img src="/aerie_ad_2.png" width="300" alt="Illustration"></img>
+          </a>
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
     <div css={gridSx}>
+      {renderAd()}
       {/* first three text articles */}
       {showFirstList ? (
         <TextContentList
@@ -114,30 +145,21 @@ export default function MixedGrid(props) {
       ) : (
         <div className="topArticles">
           {/* text article + accompanying art */}
-          <div className="div4">
+          <div className={`div4 ${!props.items[3].mainImage ? 'fullWidthContent' : ''}`}>
+            {props.items[3].mainImage && (
             <div className="div4image">
-              {props.items[3].mainImage ? (
-                <a href={"content/" + props.items[3].slug.current}>
-                  <img
-                    src={props.items[3].mainImage.asset.url}
-                    alt="Illustration"
-                  ></img>
-                </a>
-              ) : (
-                // <a href={"content/" + props.items[3].slug.current}>
-                  <a href="https://qrco.de/be9Mh6"
-                  target="_blank"
-                  rel="noreferrer">
-                  <img src="/aerie_ad_2.png" width="300" alt="Illustration"></img>
-                </a>
-              )}
+              <a href={`content/${props.items[3].slug.current}`}>
+              <img
+                src={props.items[3].mainImage.asset.url}
+                alt="Illustration"
+               /> 
+              </a>
             </div>
-            <div className="div4content">
+            )}
               <TextListElement
                 item={props.items[3]}
                 home={true}
               ></TextListElement>
-            </div>
           </div>
 
           {/* two text articles */}

--- a/web/src/components/TextListElement.js
+++ b/web/src/components/TextListElement.js
@@ -1,5 +1,6 @@
 /** @jsxImportSource theme-ui */
 import React from "react";
+import { useEffect } from 'react';
 import { Link } from "react-router-dom";
 import { Themed } from "theme-ui";
 import { PortableText } from "@portabletext/react";
@@ -84,6 +85,12 @@ const textListItemSx_home = {
       color: "text",
       WebkitLineClamp: "3",
     },
+
+    ".css-h9r693": {
+      br: {
+        display: "none",
+      }
+    },
   },
 
   p: {
@@ -119,6 +126,24 @@ const customComponents = {
 };
 
 export default function TextListItem(props) {
+  useEffect(() => {
+    document.querySelectorAll('.textPreview .css-h9r693 br').forEach(br => {
+      br.style.display = 'none';
+    });
+    const elements = document.querySelectorAll('.textPreview .css-h9r693');
+    elements.forEach(el => {
+      if (el.nodeType === 3 && el.nodeValue.includes('\u00A0')) { 
+        el.nodeValue = el.nodeValue.replace(/\u00A0/g, ' '); 
+      } else {
+        const childNodes = el.childNodes;
+        childNodes.forEach(child => {
+          if (child.nodeType === 3 && child.nodeValue.includes('\u00A0')) { 
+            child.nodeValue = child.nodeValue.replace(/\u00A0/g, ' '); 
+          }
+        });
+      }
+    });
+  }, []);
   return (
     <div css={props.home ? textListItemSx_home : textListItemSx}>
       <div css={props.padding ? padding : no_padding}>


### PR DESCRIPTION
idea #5: issue seemed to be with the way the textPreview class properties were (or rather, weren't) applying to the the text

- my workaround was to target the \<br> tags in the textPreview content and set their display to none with the useEffect hook
- i noticed that some of the previews still looked odd even with the line breaks removed and realized that the non-breaking spaces used in some pieces were making the preview look weird
- i set up a variable elements to check if the elements in the preview are node type 3 (text node) and replace them with regular spaces (the html is &nbsp but the unicode is \u00A0)
- i pass an empty array to useEffect so it only runs once after the page loads